### PR TITLE
ipyleaflet 0.19.2 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,4 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+
 aggregate_check: false

--- a/recipe/LICENSE
+++ b/recipe/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2018, Project Jupyter Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.19.2" %}
 
 package:
-  #name: {{ name }}
+  name: {{ name }}-split
   version: {{ version }}
 
 source:
@@ -17,7 +17,6 @@ source:
 build:
   number: 0
   skip: true # [py<38 or s390x]
-  #script: {{ PYTHON }} -m pip install ipyleaflet --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -42,11 +41,6 @@ outputs:
         - hatchling
         - jupyterlab >=4,<5
         - hatch-nodejs-version >=0.3.2
-      # run:
-      #   - hatch-jupyter-builder >=0.8.1
-      #   - jupyterlab >=4,<5
-      #   - hatch-nodejs-version >=0.3.2
-        
     
   - name: {{ name }}
     version: {{ version }}
@@ -66,39 +60,18 @@ outputs:
         - jupyter_leaflet
       run_constrained:
         - jupyter_leaflet ={{ version }}
-    # test:
-    #   requires:
-    #     - python
-    #   imports:
-    #     - ipyleaflet
-
-# requirements:
-#   host:
-#     - python
-#     - pip
-#     - hatchling
-#     - setuptools
-#     - wheel
-#     - jupyter-packaging >=0.12,<1
-#   run:
-#     - python
-#     - ipywidgets >=7.6.0,<9
-#     - traittypes >=0.2.1,<0.3.0
-#     - xyzservices >=2021.8.1
-#     - branca >=0.5.0
-#     - jupyter-leaflet
-
-test:
-  imports:
-    - ipyleaflet
-  requires:
-    - pip
-    - m2-grep # [win]
-    - jupyterlab
-  commands:
-    - pip check
-    - jupyter labextension list
-    - jupyter labextension list 2>&1 | grep -ie " jupyter-leaflet.*OK"
+    test:
+      imports:
+        - ipyleaflet
+      requires:
+        - pip
+        - m2-grep # [win]
+        - jupyterlab
+        - python
+      commands:
+        - pip check
+        - jupyter labextension list
+        - jupyter labextension list 2>&1 | grep -ie " jupyter-leaflet.*OK"
 
 about:
   home: https://github.com/jupyter-widgets/ipyleaflet

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,16 +42,20 @@ outputs:
         - jupyterlab >=4,<5
         - hatch-nodejs-version >=0.3.2
     test:
+      imports:
+        - jupyter_leaflet
       requires:
         - python
+        - pip
       commands:
+        - pip check
         - test -f ${PREFIX}/share/jupyter/nbextensions/jupyter-leaflet/extension.js                             # [unix]
         - test -f ${PREFIX}/share/jupyter/nbextensions/jupyter-leaflet/index.js                                 # [unix]
         - test -f ${PREFIX}/share/jupyter/labextensions/jupyter-leaflet/package.json                            # [unix]
         - if not exist %PREFIX%\\share\\jupyter\\nbextensions\\jupyter-leaflet\\extension.js (exit 1)           # [win]
         - if not exist %PREFIX%\\share\\jupyter\\nbextensions\\jupyter-leaflet\\index.js (exit 1)               # [win]
         - if not exist %PREFIX%\\share\\jupyter\\labextensions\\jupyter-leaflet\\package.json (exit 1)          # [win]
-    
+
   - name: ipyleaflet
     version: {{ version }}
     build:
@@ -73,14 +77,21 @@ outputs:
       test:
         requires:
           - python
+          - pip
         imports:
           - ipyleaflet
+        commands:
+          - pip check
 about:
   home: https://github.com/jupyter-widgets/ipyleaflet
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: A Jupyter / Leaflet bridge enabling interactive maps in the Jupyter notebook.
+  description: |
+    Ipyleaflet is a Jupyter widget for Leaflet.js , enabling interactive maps in the Jupyter notebook.
+    Every object in ipyleaflet (including the Map, TileLayers, Layers, Controls, etc.) is interactive: 
+    you can dynamically update attributes from Python or from the browser.
   doc_url: https://ipyleaflet.readthedocs.io
   dev_url: https://github.com/jupyter-widgets/ipyleaflet
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,11 +21,6 @@ build:
 requirements:
   host:
     - python
-    - pip
-    - hatchling
-    - setuptools
-    - wheel
-    - jupyter-packaging >=0.12,<1
 
 outputs:
   - name: jupyter_leaflet
@@ -71,9 +66,7 @@ outputs:
         - traittypes >=0.2.1,<0.3.0
         - xyzservices >=2021.8.1
         - branca >=0.5.0
-        - jupyter_leaflet
-      run_constrained:
-        - jupyter_leaflet ={{ version }}
+        - {{ pin_subpackage('jupyter_leaflet', max_pin='x.x') }}
       test:
         requires:
           - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,8 +41,18 @@ outputs:
         - hatchling
         - jupyterlab >=4,<5
         - hatch-nodejs-version >=0.3.2
+    test:
+      requires:
+        - python
+      commands:
+        - test -f ${PREFIX}/share/jupyter/nbextensions/jupyter-leaflet/extension.js                             # [unix]
+        - test -f ${PREFIX}/share/jupyter/nbextensions/jupyter-leaflet/index.js                                 # [unix]
+        - test -f ${PREFIX}/share/jupyter/labextensions/jupyter-leaflet/package.json                            # [unix]
+        - if not exist %PREFIX%\\share\\jupyter\\nbextensions\\jupyter-leaflet\\extension.js (exit 1)           # [win]
+        - if not exist %PREFIX%\\share\\jupyter\\nbextensions\\jupyter-leaflet\\index.js (exit 1)               # [win]
+        - if not exist %PREFIX%\\share\\jupyter\\labextensions\\jupyter-leaflet\\package.json (exit 1)          # [win]
     
-  - name: {{ name }}
+  - name: ipyleaflet
     version: {{ version }}
     build:
       script: cd ipyleaflet && python -m pip install . --no-deps --no-build-isolation -vv
@@ -60,19 +70,11 @@ outputs:
         - jupyter_leaflet
       run_constrained:
         - jupyter_leaflet ={{ version }}
-    test:
-      imports:
-        - ipyleaflet
-      requires:
-        - pip
-        - m2-grep # [win]
-        - jupyterlab
-        - python
-      commands:
-        - pip check
-        - jupyter labextension list
-        - jupyter labextension list 2>&1 | grep -ie " jupyter-leaflet.*OK"
-
+      test:
+        requires:
+          - python
+        imports:
+          - ipyleaflet
 about:
   home: https://github.com/jupyter-widgets/ipyleaflet
   license: MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,32 +1,92 @@
-{% set version = "0.17.4" %}
-{% set sha256 = "70e8772fe501da05a57e84a11734bf35fdd6b7dfb556a3dbfe93b5ab6fe747ae" %}
+{% set name = "ipyleaflet" %}
+{% set version = "0.19.2" %}
 
 package:
-  name: ipyleaflet
+  #name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/i/ipyleaflet/ipyleaflet-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  - url: https://pypi.org/packages/source/i/ipyleaflet/ipyleaflet-{{ version }}.tar.gz
+    sha256: b3b83fe3460e742964c2a5924ea7934365a3749bb75310ce388d45fd751372d2
+    folder: ipyleaflet
+  - url: https://pypi.org/packages/source/j/jupyter_leaflet/jupyter_leaflet-{{ version }}.tar.gz
+    sha256: b09b5ba48b1488cb61da37a6f558347269eb53ff6d64dc1a73e005ffc4420063
+    folder: jupyter_leaflet
+
 
 build:
   number: 0
-  skip: true # [py<37 or s390x]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true # [py<38 or s390x]
+  #script: {{ PYTHON }} -m pip install ipyleaflet --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - python
     - pip
+    - hatchling
     - setuptools
     - wheel
     - jupyter-packaging >=0.12,<1
-  run:
-    - python
-    - ipywidgets >=7.6.0,<9
-    - traittypes >=0.2.1,<0.3.0
-    - xyzservices >=2021.8.1
-    - branca >=0.5.0
+
+outputs:
+  - name: jupyter_leaflet
+    version: {{ version }}
+    build:
+      script: cd jupyter_leaflet && python -m pip install . --no-deps --no-build-isolation -vv
+    requirements:
+      host:
+        - python
+        - pip
+        - nodejs >=18,<19
+        - hatch-jupyter-builder >=0.8.1
+        - hatchling
+        - jupyterlab >=4,<5
+        - hatch-nodejs-version >=0.3.2
+      # run:
+      #   - hatch-jupyter-builder >=0.8.1
+      #   - jupyterlab >=4,<5
+      #   - hatch-nodejs-version >=0.3.2
+        
+    
+  - name: {{ name }}
+    version: {{ version }}
+    build:
+      script: cd ipyleaflet && python -m pip install . --no-deps --no-build-isolation -vv
+    requirements:
+      host:
+        - python
+        - pip
+        - hatchling
+      run:
+        - python
+        - ipywidgets >=7.6.0,<9
+        - traittypes >=0.2.1,<0.3.0
+        - xyzservices >=2021.8.1
+        - branca >=0.5.0
+        - jupyter_leaflet
+      run_constrained:
+        - jupyter_leaflet ={{ version }}
+    # test:
+    #   requires:
+    #     - python
+    #   imports:
+    #     - ipyleaflet
+
+# requirements:
+#   host:
+#     - python
+#     - pip
+#     - hatchling
+#     - setuptools
+#     - wheel
+#     - jupyter-packaging >=0.12,<1
+#   run:
+#     - python
+#     - ipywidgets >=7.6.0,<9
+#     - traittypes >=0.2.1,<0.3.0
+#     - xyzservices >=2021.8.1
+#     - branca >=0.5.0
+#     - jupyter-leaflet
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ outputs:
       host:
         - python
         - pip
-        - nodejs >=18,<19
+        - nodejs
         - hatch-jupyter-builder >=0.8.1
         - hatchling
         - jupyterlab >=4,<5


### PR DESCRIPTION
ipyleaflet 0.19.2 

**Destination channel:** Defaults

### Links

- [PKG-7303]
- dev_url:        https://github.com/jupyter-widgets/ipyleaflet/tree/0.19.2
- conda_forge:    https://github.com/conda-forge/ipyleaflet-feedstock
- pypi:           https://pypi.org/project/ipyleaflet/0.19.2
- pypi inspector: https://inspector.pypi.io/project/ipyleaflet/0.19.2

### Explanation of changes:

- new version number
- converted to multi output recipe due to new requirement of `jupyter_leaflet`, that comes from within the same upstream repo


[PKG-7303]: https://anaconda.atlassian.net/browse/PKG-7303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ